### PR TITLE
Add compiling the magicfile into wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ jobs:
           path: dist
           key: cache-build-artifacts-${{ github.sha }}
 
-      - uses: mymindstorm/setup-emsdk@v9
+      - uses: mymindstorm/setup-emsdk@v10
+        with:
+          version: 2.0.27
 
       - name: Setup build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends autoconf automake libtool
+          sudo apt-get install -y --no-install-recommends autoconf automake libtool xxd
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/Dockerfile.Builder
+++ b/Dockerfile.Builder
@@ -1,8 +1,9 @@
-FROM emscripten/emsdk:2.0.26
+FROM emscripten/emsdk:2.0.27
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   autoconf \
   automake \
   libtool \
+  xxd \
   && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ package: dist/index.js dist/libmagic.LICENSE
 dist/index.js: src/*.ts src/test/integration/*.ts dist/wasmagic.js
 	npx ttsc -d
 
-dist/wasmagic.js: src/wasmagic.c dist/magic.mgc dist/libmagic.so
+dist/wasmagic.js: src/wasmagic.c dist/magicfile.h dist/libmagic.so
 	emcc -s MODULARIZE -s WASM=1 \
-	-s EXPORTED_RUNTIME_METHODS='["cwrap", "FS"]' \
+	-s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
 	-s EXPORTED_FUNCTIONS='["_wasmagic_get_mime", "_free"]' \
 	-s ALLOW_MEMORY_GROWTH=1 \
-	-I./vendor/file/src -L./dist \
+	-I./vendor/file/src -I./dist -L./dist \
 	-lmagic \
 	-o dist/wasmagic.js \
 	src/wasmagic.c
@@ -33,6 +33,9 @@ dist/magic.mgc: vendor/file/COPYING
 	&& ./configure --disable-silent-rules \
 	&& make \
 	&& cp magic/magic.mgc ../../dist/
+
+dist/magicfile.h: dist/magic.mgc
+	xxd -i dist/magic.mgc dist/magicfile.h
 
 dist/libmagic.so: vendor/file/COPYING
 	make clean-vendor-file \

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ npm install wasmagic
 const { WASMagic } = require("wasmagic");
 
 async function main() {
-    const magic = await WASMagic.create();
-    const pngFile = Buffer.from('89504E470D0A1A0A0000000D49484452', 'hex');
-    console.log(magic.getMime(pngFile));
+  const magic = await WASMagic.create();
+  const pngFile = Buffer.from("89504E470D0A1A0A0000000D49484452", "hex");
+  console.log(magic.getMime(pngFile));
 }
 
-main().catch(err => console.error(err));
+main().catch((err) => console.error(err));
 // outputs: image/png
 ```
 
@@ -36,15 +36,15 @@ of the file you want to detect, or slice the head off of a file buffer:
 
 ```javascript
 const { WASMagic } = require("wasmagic");
-const fs = require('fs');
+const fs = require("fs");
 
 async function main() {
-    const magic = await WASMagic.create();
-    const largeFile = fs.readFileSync('largeFile.mp4');
-    console.log(magic.getMime(largeFile.slice(0, 1024)));
+  const magic = await WASMagic.create();
+  const largeFile = fs.readFileSync("largeFile.mp4");
+  console.log(magic.getMime(largeFile.slice(0, 1024)));
 }
 
-main().catch(err => console.error(err));
+main().catch((err) => console.error(err));
 // outputs: video/mp4
 ```
 
@@ -59,8 +59,8 @@ to detect, be sure to test example files.
 
 ### Detected filetypes
 
-WASMagic detects any file type detected by
-[libmagic](https://github.com/file/file/tree/master/magic/Magdir), which is over
+WASMagic detects any file type [detected by
+libmagic](https://github.com/file/file/tree/master/magic/Magdir), which is over
 1500 mime types. For comparison; the
 [file-type](https://www.npmjs.com/package/file-type) library supports 138 types.
 

--- a/dist/.npmignore
+++ b/dist/.npmignore
@@ -1,5 +1,4 @@
 *
 !index.*
 !*LICENSE
-!magic.mgc
 !wasmagic.*

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
 import wasmagicFactory from "wasmagic"; // ./dist/wasmagic.js
-import { readFileSync } from "fs";
-import { join } from "path";
-
-const magicFile = readFileSync(join(__dirname, "magic.mgc"));
 
 export class WASMagic {
   static async create(): Promise<WASMagic> {
@@ -15,16 +11,13 @@ export class WASMagic {
 
   private constructor(Module: WasMagicModule) {
     this.Module = Module;
-    const writeStream = this.Module.FS.open("/magic.mgc", "w+");
-    this.Module.FS.write(writeStream, magicFile, 0, magicFile.length, 0);
-    this.Module.FS.close(writeStream);
     this.getMimeFromWasm = Module.cwrap("wasmagic_get_mime", "string", [
       "number",
       "number",
     ]) as typeof wrappedGetMime;
   }
 
-  getMime(buf: Buffer): string {
+  getMime(buf: Uint8Array): string {
     const ptr = this.Module._malloc(buf.length);
     this.Module.HEAPU8.set(buf, ptr);
     const result = this.getMimeFromWasm(ptr, buf.length);

--- a/src/wasmagic.c
+++ b/src/wasmagic.c
@@ -1,13 +1,16 @@
 #include <stddef.h>
+#include "magicfile.h"
 #include "magic.h"
 
 struct magic_set *ms = NULL;
+void *magic_buffers = &dist_magic_mgc;
+size_t *magic_buffers_sizes = (size_t*)&dist_magic_mgc_len;
 
 void wasmagic_load()
 {
   if (ms == NULL) {
     ms = magic_open(0 | MAGIC_MIME_TYPE);
-    magic_load(ms, "/magic.mgc");
+    magic_load_buffers(ms, &magic_buffers, magic_buffers_sizes, 1);
   }
 }
 


### PR DESCRIPTION
This means one less step during setup, and also makes the library
compatible with running in browser