### PR TITLE
Fix StdioOverrideFunction Type export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist/test/integration/foobar_magic dist/test/integration/png_magic dist/test/int
 
 package: dist/index.js dist/libmagic.LICENSE
 
-dist/index.js: $(ts_files) dist/libmagic-wrapper.js
+dist/index.js: $(ts_files) dist/libmagic-wrapper.js dist/LibmagicModule.d.ts dist/StdioOverrideFunction.d.ts
 	npx tsc -d
 
 dist/libmagic-wrapper.js: src/libmagic-wrapper.c dist/magic.mgc dist/libmagic.so dist/libmagic-wrapper.d.ts
@@ -31,8 +31,14 @@ dist/libmagic-wrapper.js: src/libmagic-wrapper.c dist/magic.mgc dist/libmagic.so
 	-o dist/libmagic-wrapper.js \
 	src/libmagic-wrapper.c
 
-dist/libmagic-wrapper.d.ts: types/libmagic-wrapper.d.ts
-	cp types/libmagic-wrapper.d.ts dist/libmagic-wrapper.d.ts
+dist/libmagic-wrapper.d.ts: src/libmagic-wrapper.d.ts
+	cp src/libmagic-wrapper.d.ts dist/libmagic-wrapper.d.ts
+
+dist/LibmagicModule.d.ts: src/LibmagicModule.d.ts
+	cp src/LibmagicModule.d.ts dist/LibmagicModule.d.ts
+
+dist/StdioOverrideFunction.d.ts: src/StdioOverrideFunction.d.ts
+	cp src/StdioOverrideFunction.d.ts dist/StdioOverrideFunction.d.ts
 
 dist/libmagic.LICENSE: vendor/file/COPYING
 	cp vendor/file/COPYING dist/libmagic.LICENSE

--- a/dist/.npmignore
+++ b/dist/.npmignore
@@ -2,3 +2,5 @@
 !index.*
 !*LICENSE
 !libmagic-wrapper.*
+!LibmagicModule.d.ts
+!StdioOverrideFunction.d.ts

--- a/src/LibmagicModule.d.ts
+++ b/src/LibmagicModule.d.ts
@@ -1,7 +1,4 @@
-type StdioOverrideFunction = (
-  stdioName: "stdout" | "stderr",
-  text: string,
-) => void;
+import StdioOverrideFunction from "./StdioOverrideFunction";
 
 interface LibmagicModule extends EmscriptenModule {
   FS: typeof FS;
@@ -9,3 +6,5 @@ interface LibmagicModule extends EmscriptenModule {
   cwrap: typeof cwrap;
   printOverride: StdioOverrideFunction;
 }
+
+export default LibmagicModule;

--- a/src/StdioOverrideFunction.d.ts
+++ b/src/StdioOverrideFunction.d.ts
@@ -1,0 +1,6 @@
+type StdioOverrideFunction = (
+  stdioName: "stdout" | "stderr",
+  text: string,
+) => void;
+
+export default StdioOverrideFunction;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import libmagicFactory from "../dist/libmagic-wrapper";
+import libmagicFactory from "./libmagic-wrapper";
+import LibmagicModule from "./LibmagicModule";
+import StdioOverrideFunction from "./StdioOverrideFunction";
+export { default as StdioOverrideFunction } from "./StdioOverrideFunction";
 
 declare function wrappedDetect(bufPointer: number, bufLength: number): string;
 

--- a/src/libmagic-wrapper.d.ts
+++ b/src/libmagic-wrapper.d.ts
@@ -1,2 +1,4 @@
+import LibmagicModule from "./LibmagicModule";
+
 declare const factory: EmscriptenModuleFactory<LibmagicModule>;
 export default factory;


### PR DESCRIPTION
This was a case of bad management of the types in play and their exposure outside the package. The fix that works for both package maintenance, and external users is to ensure that the type is available and copied into the final npm package. Finally this would have been caught with a test, which has now been added.

- Fix #40
- Add dedicated type file for StdioOverrideFunction
- Change type file paths to be relative
- Move all type files to the `src` folder to make things easier
- Add Makefile rules to copy over `.d.ts` files so they are in the package